### PR TITLE
Add type to 1.x composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "mehrpadin/superfish",
   "homepage": "https://github.com/mehrpadin/Superfish-for-Drupal",
   "description": "Superfish library for the Drupal Superfish module.",
+  "type": "drupal-library",
   "repository": {
     "type": "git",
     "url": "git://github.com/mehrpadin/Superfish-for-Drupal"


### PR DESCRIPTION
Add a composer type field to allow composer to place this library in the correct location for Composer managed Drupal sites.